### PR TITLE
Fix: remove userStore localStorage in logout user

### DIFF
--- a/src/layouts/UserLayout.vue
+++ b/src/layouts/UserLayout.vue
@@ -21,6 +21,7 @@
       behavior="mobile"
       bordered
       dark
+      class="col"
     >
       <div
         class="column justify-center items-center"
@@ -55,6 +56,19 @@
           v-bind="link"
         />
       </q-list>
+      <div class="row justify-center">
+        <q-btn
+          rounded
+          class="q-mt-xl"
+          color="white"
+          icon="logout"
+          flat
+          size="md"
+          label="Logout"
+          @click="logout"
+          style="font-size: 1.1em"
+        />
+      </div>
     </q-drawer>
 
     <q-page-container>
@@ -89,10 +103,11 @@
   import DeckCard from 'src/components/DeckCard.vue';
   import { getMeCards } from 'src/services/Cards';
   import { showNegativeNotify } from 'src/utils/plugins';
+  import { useRouter } from 'vue-router';
   import { EssentialLinkProps } from 'src/types/Links';
 
   defineOptions({
-    name: 'UserLayout',
+    name: 'MainLayout',
   });
 
   onBeforeMount(async () => {
@@ -125,9 +140,15 @@
     userStore.getUsername,
   );
   const userCards = reactive<Card[]>([]);
+  const router = useRouter();
 
   const handleShowDeck = () => {
     deckStore.showDeck();
+  };
+
+  const logout = () => {
+    localStorage.clear();
+    router.push('/');
   };
 
   const toggleLeftDrawer = () => {


### PR DESCRIPTION
## Estou enviando um...

- [x] Correção de bug
- [ ] Nova Feature

## Qual é o comportamento atual?
Local storage com dados do usuário não estava sendo removido

## Se o comportamento atual é um bug, por favor forneça os passos para reproduzir e, se possível, um exemplo mínimo do problema
Faça logout e visualize os dados do user ainda no local storage do navegador

## Qual é o comportamento esperado?
Espera-se que remova os dados ao fazer logout

## Qual é a motivação / caso de uso para a mudança de comportamento?
Segurança do usuário
